### PR TITLE
Add data to heartbeat message

### DIFF
--- a/internal/bridge/subscribe.go
+++ b/internal/bridge/subscribe.go
@@ -14,7 +14,7 @@ import (
 	"tonconnect-bridge/internal/bridge/metrics"
 )
 
-var heartbeat = []byte("event: heartbeat\r\n\r\n")
+var heartbeat = []byte("event: heartbeat\r\ndata: \r\n\n")
 
 func (s *SSE) handleSubscribe(ctx *fasthttp.RequestCtx, ip string, authorized bool) {
 	idsStr := string(ctx.QueryArgs().Peek("client_id"))

--- a/internal/bridge/subscribe.go
+++ b/internal/bridge/subscribe.go
@@ -14,7 +14,7 @@ import (
 	"tonconnect-bridge/internal/bridge/metrics"
 )
 
-var heartbeat = []byte("event: heartbeat\r\ndata: \r\n\n")
+var heartbeat = []byte("event: message\r\ndata: heartbeat\r\n\n")
 
 func (s *SSE) handleSubscribe(ctx *fasthttp.RequestCtx, ip string, authorized bool) {
 	idsStr := string(ctx.QueryArgs().Peek("client_id"))


### PR DESCRIPTION
We can't access heartbeat events right now, because the heartbeat without a data section breaks the specification https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage